### PR TITLE
Remove superfluous parenthese

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
         return [p[0] / 100, p[1] * sign / 100];
       });
     }
-  })();
+  }();
 
   // Builds an m + 1 x n matrix of edge shapes. The first and last rows
   // are straight edges.


### PR DESCRIPTION
While trying to learn about Easel helpers, I noticed an error in the console (Also the app coundn't run) and I fixed it by removing the superfluous parenthese.